### PR TITLE
No routes

### DIFF
--- a/models/actions/book/user-goals/CommitOrder.model.bxb
+++ b/models/actions/book/user-goals/CommitOrder.model.bxb
@@ -10,6 +10,11 @@ action (CommitOrder) {
     input (order) {
       type (Order)
       min (Required)
+      default-init {
+        intent {
+          goal: CreateOrder
+        }
+      }
     }
   }
   output (Receipt)

--- a/models/actions/book/user-goals/CreateOrder.model.bxb
+++ b/models/actions/book/user-goals/CreateOrder.model.bxb
@@ -6,6 +6,11 @@ action (CreateOrder) {
     input (item) {
       type (Item)
       min (Required)
+      default-init {
+        intent {
+          goal: CreateItem
+        }
+      }
     }
 
     input (buyer) {

--- a/resources/base/layouts/SpaceResort/Input_ToBook.view.bxb
+++ b/resources/base/layouts/SpaceResort/Input_ToBook.view.bxb
@@ -7,7 +7,7 @@ input-view {
   }
   render {
     selection-of (result) {
-      //has-details (true)
+      has-details (true)
       select-button-text{ template-macro (Book)}
       where-each (item) {
         layout-macro (space-resort-summary) {

--- a/resources/en/training/t-3.training.bxb
+++ b/resources/en/training/t-3.training.bxb
@@ -1,5 +1,5 @@
 train (t-3ktlcvll2yqe8v2uu5y1czlp7) {
-  utterance ("[g:CommitOrder,r:CreateItem,r:CreateOrder] make a reservation at a space resort with a (spa)[v:SearchCriteria] for (two)[v:NumberOfAstronauts:2] astronauts")
-  plan (fY/basJAFEW39dJG6we0FGyR0jf/wQtiX7ToFxyTUxzIJOHMidS/d4xSfZjIwNzW2psZ9PHGf2SLlEeuoJjX7HJRN1pzzKZQvAfpNLfW6EoSFrwGjTOrSQuT8r30pDx49hJk38oWgzvFlfARFGYnnCnLntKajgVtjZL+5Am+gsKytFuW1e/YqeQZlepqvrm5HvAZNOYmS24sh2G4iEni3VSMf7ghPKOBBzTRQhsdPOIJEbro+XtcSLMi53EijYrgf77u2n6NfLLjMzgC)
-  last-modified (1555008344996)
+  utterance ("[g:CommitOrder] make a reservation at a space resort with a (spa)[v:SearchCriteria] for (two)[v:NumberOfAstronauts:2] astronauts")
+  plan (fY/dasJAEIWPRm21+gBKoS1FvPMdqiJ6o2KfYEymdMFNwuxE9O1NoqgXG1nYv+87h1308M5Hsumexy6lkLfsElE33nLIJlV8euk0sdboWiIWDLzGhVWkhUn5WXqSnXLW97KlssXHk+JS+PIKswLHynKgfUXHgnZGSTdJhJFXWGV2x7L++3EqSUyZuopv/t4PGHqNuYmjB8vh21/EJOH/VEz+cEPoooY6AjTQRAsveEUbHbzl97iSoCSXUZBaSXCb77sgX9tF8gw=)
+  last-modified (1556576589393)
 }

--- a/resources/en/training/t-b.training.bxb
+++ b/resources/en/training/t-b.training.bxb
@@ -1,5 +1,5 @@
 train (t-bzgmf11fzx2nv8si00p6q6kqg) {
-  utterance ([g:CommitOrder:continue:SpaceResort,r:CreateOrder,r:CreateItem] Make reservation)
-  plan (fY9NDoJADIUf4r8n0JioK3fcwZ+FbsTgCQaoCQnDkJli9PaOYHQz0CZN+r73mhQzLOkpZJlTYEqRUERGaTZBRAllJWPtpAclZcahTklj4XQ0rCWtSTB1pffVy7K5k52ZJFYdh2vDxmk4fnDBpB8ib7lxEnHGgq8qxdZpuFQyJh3ed4a1KkTFpuXN23/BFB568NHHAEOMMMbEaviqfq027dUqfrMp325DO/EG)
-  last-modified (1555008347090)
+  utterance ([g:CommitOrder:continue:SpaceResort] Make reservation)
+  plan (Y2BmkEmtSMwtyEnVKy5ITE4NSi3OLyop1gtKTU7NLChhUMAq65yfm5tZ4l+UklrEIIVVBUSOiYERiBmAJCMDA4wGAA==)
+  last-modified (1556576711535)
 }

--- a/resources/en/training/t-d.training.bxb
+++ b/resources/en/training/t-d.training.bxb
@@ -1,7 +1,7 @@
 train (t-ddocty9ld4kzu73rc7qqg1610) {
-  utterance ("[g:CommitOrder,r:CreateItem,r:CreateOrder] Book a space resort with (zero gravity)[v:SearchCriteria]")
-  plan (fY/dagIxEEY/u7b+1D5ARWhFxDvfwSrF3qjoE4y7IwbM7jKZLe3bG1dRL7ISmCRzznwkeEOP/8jmBx67nGJes8tE3XjNMZtc8Rmk08xao0tJWNANGmdWMS1Myo+mv4p/z96D7EfZ4uNBcCn0g8LshFNl+aVDRcactkZJV1mCUVBYFHbLstxNnEqWUqGu4pub2wXDoPFt0uTOchiEg5gk3k/F+IcbQgc1PCFCHc94QQNNtNDGq+/jQqKSnNeJ1EqCa72d6n7veCsCjg==)
-  last-modified (1555008347333)
+  utterance ("[g:CommitOrder] Book a space resort with (zero gravity)[v:SearchCriteria]")
+  plan (fY/basJAFEV3vPaiH6AIbZHSN//BWkp9UbFfcExOcSCThDMnon/vGIv6MJGBua21NzPoY8R7skXKE1dQzGt2uaibrDlmUyheg3SWW2t0KQkLhkHjzGrSwqR8L/1ZHjwbBNlc2eLlTnElvAWFrxPOlGVHaU3HD22Mkq7yBB9BYVHaDcvyb+pU8oxKdTXf/L0e8B40vk2W3FgO43ARk8TbmRj/cEPoIUIDTbTQRgddPOART3j29/gnzYqcx4lEFcFlvu4afvW5Iw==)
+  last-modified (1556576730860)
 }
 train (t-drmvf6shdvv4ssmu0eu1j8ene) {
   utterance ([g:CommitOrder:continue,r:UpdateOrder,r:GetDateInterval] Pick a different date)

--- a/resources/en/training/t-o.training.bxb
+++ b/resources/en/training/t-o.training.bxb
@@ -7,9 +7,9 @@ train (t-o9cm329ghna15lrdfv68w9rbu) {
   plan (Y2BhkE+tSMwtyEnVKy5ITE4NSi3OLyop1vNITMosSSwJyE9hkMOqIDg1JzUZLE/QABmsCoAyfom5qQzMDIwMTECSAUiDIAQwATFQDAA=)
 }
 train (t-oarb3ywljx6o1ivq1ft1ft6l7) {
-  utterance ([g:CommitOrder,r:CreateOrder,r:CreateItem] Book a space resort)
-  plan (fY9NDoJADIUf4r8n0JioK3fcwZ+FbsTgCQaoCQnDkJli9PaOYHQz0CZN+r73mhQzLOkpZJlTYEqRUERGaTZBRAllJWPtpAclZcahTklj4XQ0rCWtSTB1pffVy7K5k52ZJFYdh2vDxmk4fnDBpB8ib7lxEnHGgq8qxdZpuFQyJh3ed4a1KkTFpuXN23/BFB568NHHAEOMMMbEaviqfq027dUqfrMp325DO/EG)
-  last-modified (1555008351533)
+  utterance ([g:CommitOrder] Book a space resort)
+  plan (Y2BmkEmtSMwtyEnVKy5ITE4NSi3OLyop1gtKTU7NLChhUMAq65yfm5tZ4l+UklrEIIVVBUSOiYERiBmAJCMDA4wGAA==)
+  last-modified (1556576780803)
 }
 train (t-ofjt1uo89vogb7310kdcw9s89) {
   utterance ("[g:SpaceResort:prompt,r:SelectResort] with a (spa)[v:SearchCriteria]")
@@ -17,7 +17,7 @@ train (t-ofjt1uo89vogb7310kdcw9s89) {
   last-modified (1547753479979)
 }
 train (t-ooyyhs9uge7hpyo9du67pkjin) {
-  utterance ([g:CommitOrder:continue:SpaceResort,r:CreateOrder,r:CreateItem] Book it)
-  plan (fY9NDoJADIUf4r8n0JioK3fcwZ+FbsTgCQaoCQnDkJli9PaOYHQz0CZN+r73mhQzLOkpZJlTYEqRUERGaTZBRAllJWPtpAclZcahTklj4XQ0rCWtSTB1pffVy7K5k52ZJFYdh2vDxmk4fnDBpB8ib7lxEnHGgq8qxdZpuFQyJh3ed4a1KkTFpuXN23/BFB568NHHAEOMMMbEaviqfq027dUqfrMp325DO/EG)
-  last-modified (1555008351893)
+  utterance ([g:CommitOrder:continue:SpaceResort] Book it)
+  plan (Y2BmkEmtSMwtyEnVKy5ITE4NSi3OLyop1gtKTU7NLChhUMAq65yfm5tZ4l+UklrEIIVVBUSOiYERiBmAJCMDA4wGAA==)
+  last-modified (1556576773542)
 }

--- a/resources/en/training/t-p.training.bxb
+++ b/resources/en/training/t-p.training.bxb
@@ -4,9 +4,9 @@ train (t-p0xltp3ympg12v0v80yc3jy1o) {
   last-modified (1549558939136)
 }
 train (t-p65k12lzx32efijdjjt6n7sy7) {
-  utterance ("[g:CommitOrder,r:CreateItem,r:CreateOrder] Book a space resort on (Pluto)[v:Planet:Pluto]")
-  plan (fY/ZCsIwEEVvrbv1A1xAfRDf/AcXRF9U9AtiO0KhaUsyFf17u4j1IZWBZJJz7sCgjzE9hYwDWupYuHQhHSnWywu55MeMqZFuIil9PimPFIZGo2AVaUWC6V96nbxSNjCyA5PE5M/gXJgZhW2GQyb1EEHFjL24+Sz4HHlYGIVjIm+kTveVZhWFImFdsea1fGBuNHZ+6P1YGiOjdg5ESAwHFmqwUUcDTbTQRgdd9NJ/fIidk6IyYuUE37Ps6untpJYNvAE=)
-  last-modified (1555008352274)
+  utterance ("[g:CommitOrder] Book a space resort on (Pluto)[v:Planet:Pluto]")
+  plan (fY/ZCsIwEEWv+/4BLqA+iG/+gwuiL7bUL0jbEQpNW5Kp6N/bVlEf0hLITOacOxCMMKOHkElIG50IjxzSsWK9ccijIGEsjHQfSxmwpXxSmBiNNytJKxJMVeld+szY2MjOTBLzisWFsDQKhxxHTOouwpIdJ+EGLNiOfayNwiWVLinrttWs4kikrEu+ef09sDIaxyDy/yyNqVGzQxERY4ga6migiRba6KCLHvoYZHN8SKMg75OTWkHwvX9dPatZ7gU=)
+  last-modified (1556576787704)
 }
 train (t-p9awei12qfzo1kcgr6xmko7cl) {
   utterance ("[g:CommitOrder:continue,r:UpdateOrder] Change that to (The Lab)[v:PodName]")

--- a/resources/en/training/t-s.training.bxb
+++ b/resources/en/training/t-s.training.bxb
@@ -1,7 +1,7 @@
 train (t-s4g3zknk1jr2ddr2fh8tdaht9) {
-  utterance ("[g:CommitOrder,r:CreateItem,r:CreateOrder] make a reservation for a space resort on (mars)[v:Planet:Mars] (the third weekend in december)[v:viv.time.DateTimeExpression] for (2)[v:NumberOfAstronauts] people")
-  plan (fZDLTsMwEEUvFEJbXmsoEu0Cscs38KxgQ6vCD7jJVLIU29F4EpW/xwmVmoVTWZZndM6MPcY17mirTFlQ6kuV0Yq8Y/HpijLSpWAapa/OGC0LzolxGzX+WU81kxI6VP1S/QZ2E2WfQgb3Bxq3wiwqvDXYCnGtCjz1jGa9cJVJ152zM03+ow29b0sm77WzPa/4UGstSpYux2NU+KrMmnixeQ4XOasq8T0f9b1P8BA15trmHctjEtWWhbIkmNS6TiXMkEaGucIRjjHACU6R4AxDjDDGOS5wGRh2dLCjSbsaOgwE7UYn2p9JiMahRxJqQ58/)
-  last-modified (1555008353216)
+  utterance ("[g:CommitOrder] make a reservation for a space resort on (mars)[v:Planet:Mars] (the third weekend in december)[v:viv.time.DateTimeExpression] for (2)[v:NumberOfAstronauts] people")
+  plan (fZDLbsIwEEVvC6WUvtYtlVoWVXf5hj4RbAqi/QGTDJKl2I7Gk4j+fZ2ARBYOsizP6JwZe4xbPNBWmSKnxBcqpRV5x+KTFaWkC8FTlH44Y7QsOCPGfdTYsY5qJiV0rPq9/AvsLsrmQgaPRxo3wiQqfNbYCnGlcrx2jGa9cJlK252yM3X+qw19bQsm77WzHa+YqbUWJUuX4SUqfJdmTbzYvIWLnFWl+I6P+jkkeI4aU22zluUxjmrLXFkSjCtdJRJmSCLD3OAEp+ihjzMMcI4hLjDCJa5wHRj2tLeng2bVdBgImo1WdDj7IRrtevwD)
+  last-modified (1556576691780)
 }
 train (t-sk0zgndhhzh1irhopmxe59o4c) {
   utterance ("[g:SpaceResort:prompt,r:SelectResort] (The Mercurial)[v:Name]")


### PR DESCRIPTION
Removed routes to CreateItem and CreateOrder and linked the actions through the usage of default-init in input collect.

The planner doesn't look at default-init so it may not connect the dots, but NL examples trained to CommitOrder will work on runtime.