### PR TITLE
Result view updated to make intent from introductory video work

### DIFF
--- a/resources/base/layouts/SpaceResort/Result.view.bxb
+++ b/resources/base/layouts/SpaceResort/Result.view.bxb
@@ -5,6 +5,20 @@ result-view {
   }
 
   render {
+
+    // To keep intent from "Teaching Bixby Fundamentals: What You Need to Know" working properly
+    if (size(result) > 1) {
+      list-of (result) {
+        where-each (item) {
+          layout-macro (space-resort-summary) {
+            param (spaceResort) {
+              expression (item)
+            }
+          }
+        }
+      }
+    }
+
     // We know the size is always 1 because this view is only attainable when drilling into a single item to see the details
     // Lists of space resorts are handled in the ViewAll_Result and Input files
     if (size(result) == 1) {


### PR DESCRIPTION
On bixbydevelopers.com we have introductory video
(https://bixbydevelopers.com/dev/docs/sample-capsules/videos/fundamentals)
where sample intent is presented (see https://youtu.be/EYp_AhgNQWA?t=1415). 
Since intent returns 3 items and result-view is updated to handle only 1 item developer which follows video with cloned code gets empty view. This can make confusion. 

I suggest to keep this example working by leaving code snippet to handle more than one item in result view. 

Not working intent from itroductory video:
intent {
  goal {SpaceResort}
  value {Planet (Jupiter)}
  value {SearchCriteria (refueling services)}
}
