### PR TITLE
Update library dependencies in capsule.bxb file

### DIFF
--- a/capsule.bxb
+++ b/capsule.bxb
@@ -7,18 +7,18 @@ capsule {
 		target (bixby-mobile-ko-KR)
 	}
 	
-	runtime-version (8)
+	runtime-version (9)
 	capsule-imports {
 		import (viv.core) {
 			as (core)
 		}
 		import (viv.self) {
 			as (self)
-			version (4.0.20)
+			version (4.0.21)
 		}
 		import (viv.time) {
 			as (time)
-			version (3.3.34)
+			version-from (self)
 		}
 		import (viv.money) {
 			as (money)

--- a/capsule.bxb
+++ b/capsule.bxb
@@ -22,7 +22,7 @@ capsule {
 		}
 		import (viv.money) {
 			as (money)
-			version (2.22.51)
+			version (2.22.56)
 		}
 	}
 	store-sections{


### PR DESCRIPTION
The older version of the viv.money library, currently in use by the space resort capsule, is deprecated.